### PR TITLE
feat(footer): add shared CCS Woerden footer

### DIFF
--- a/basket.html
+++ b/basket.html
@@ -64,6 +64,7 @@
       </div>
     </main>
     <script src="shop.js"></script>
+    <script src="footer.js"></script>
     <script>
       renderBasket();
       document.getElementById("clearBasket").onclick = function () {

--- a/bundles.html
+++ b/bundles.html
@@ -111,5 +111,6 @@
       </div>
     </main>
     <script src="shop.js"></script>
+    <script src="footer.js"></script>
   </body>
 </html> 

--- a/checkout.html
+++ b/checkout.html
@@ -86,6 +86,7 @@
       </div>
     </main>
     <script src="shop.js"></script>
+    <script src="footer.js"></script>
     <script>
       renderBasket();
       document.getElementById("checkoutForm").onsubmit = function (e) {

--- a/footer.js
+++ b/footer.js
@@ -1,0 +1,31 @@
+document.addEventListener("DOMContentLoaded", function () {
+  if (document.querySelector("footer.site-footer")) return;
+
+  var footer = document.createElement("footer");
+  footer.className = "site-footer";
+  footer.setAttribute("role", "contentinfo");
+
+  footer.innerHTML = [
+    '<div class="footer-content">',
+    '  <div class="footer-section">',
+    '    <h3>CCS Woerden</h3>',
+    '    <p>Stationsplein 1<br>3445 AC Woerden<br>The Netherlands</p>',
+    '  </div>',
+    '  <div class="footer-section">',
+    '    <h3>Contact</h3>',
+    '    <p>Email: info@ccs.example<br>Phone: +31 30 123 4567</p>',
+    '  </div>',
+    '  <div class="footer-section">',
+    '    <h3>Opening Hours</h3>',
+    '    <p>Mon–Fri: 09:00–17:00<br>Sat–Sun: Closed</p>',
+    '  </div>',
+    '</div>',
+    '<div class="footer-bottom">',
+    '  <p>© ' + new Date().getFullYear() + ' CCS — Fruit Shop Demo</p>',
+    '</div>'
+  ].join("");
+
+  document.body.appendChild(footer);
+});
+
+

--- a/index.html
+++ b/index.html
@@ -87,5 +87,6 @@
       </div>
     </main>
     <script src="shop.js"></script>
+    <script src="footer.js"></script>
   </body>
 </html>

--- a/personality-quiz.html
+++ b/personality-quiz.html
@@ -82,27 +82,7 @@
         </section>
     </main>
 
-    <footer>
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>About Our Mission</h3>
-                <p>Connecting people with sustainable fruit choices to create a better world, one quiz at a time.</p>
-            </div>
-            <div class="footer-section">
-                <h3>Join the Movement</h3>
-                <p>Share your results and inspire others to make conscious choices!</p>
-                <div class="social-links">
-                    <a href="#" class="social-link">Twitter</a>
-                    <a href="#" class="social-link">Facebook</a>
-                    <a href="#" class="social-link">Instagram</a>
-                </div>
-            </div>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2024 Fruit Shop. Making the world better through sustainable fruit choices.</p>
-        </div>
-    </footer>
-
     <script src="quiz.js"></script>
+    <script src="footer.js"></script>
 </body>
 </html> 

--- a/product-apple.html
+++ b/product-apple.html
@@ -64,6 +64,7 @@
     </main>
     <script src="shop.js"></script>
     <script src="fruit-facts.js"></script>
+    <script src="footer.js"></script>
     <script>
       document.getElementById("addToBasket").onclick = function () {
         addToBasket("apple");

--- a/product-banana.html
+++ b/product-banana.html
@@ -64,6 +64,7 @@
     </main>
     <script src="shop.js"></script>
     <script src="fruit-facts.js"></script>
+    <script src="footer.js"></script>
     <script>
       document.getElementById("addToBasket").onclick = function () {
         addToBasket("banana");

--- a/product-lemon.html
+++ b/product-lemon.html
@@ -64,6 +64,7 @@
     </main>
     <script src="shop.js"></script>
     <script src="fruit-facts.js"></script>
+    <script src="footer.js"></script>
     <script>
       document.getElementById("addToBasket").onclick = function () {
         addToBasket("lemon");

--- a/style.css
+++ b/style.css
@@ -16,6 +16,45 @@ body {
   margin: 0;
   color: #222;
 }
+
+/* Footer */
+.site-footer {
+  background: #111;
+  color: #f2f2f2;
+  margin-top: 3rem;
+}
+.site-footer .footer-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+.site-footer .footer-section h3 {
+  margin: 0 0 0.6rem 0;
+  font-size: 1.2rem;
+  color: #fff;
+}
+.site-footer .footer-section p {
+  margin: 0;
+  color: #ddd;
+  line-height: 1.5;
+  font-size: 1rem;
+}
+.site-footer .footer-bottom {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 1rem 2rem;
+  text-align: center;
+  color: #bbb;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .site-footer .footer-content {
+    padding: 1.5rem;
+  }
+}
 header {
   background: #f9f6f1;
   padding: 1.2rem 2.5rem;

--- a/subscription.html
+++ b/subscription.html
@@ -84,5 +84,6 @@
       document.getElementById('subscriptionForm').reset();
     };
   </script>
+  <script src="footer.js"></script>
 </body>
 </html> 


### PR DESCRIPTION
Adds a reusable footer with CCS (Woerden) address details injected across all pages via footer.js. Also removes the old hardcoded footer on the quiz page.

- New: footer.js that appends a semantic footer
- Styles: .site-footer in style.css
- Included on: index, product pages, basket, checkout, bundles, subscription, quiz

Closes #19